### PR TITLE
Revert "Pull live availability status from mylibrary/okapi for now"

### DIFF
--- a/__tests__/utils/endpointParsers.test.js
+++ b/__tests__/utils/endpointParsers.test.js
@@ -120,7 +120,7 @@ describe('enpointParsers', () => {
     it('returns outage if the live_lookups check is not successful', () => {
       const data = {
         default: { success: true },
-        okapi: { success: false },
+        live_lookups: { success: false },
       };
 
       return expect(
@@ -131,7 +131,7 @@ describe('enpointParsers', () => {
     it('returns outage if the live_lookups check is not parsable', () => {
       const data = {
         default: { success: true },
-        okapi: 'NOPE!',
+        live_lookups: 'NOPE!',
       };
 
       return expect(
@@ -142,7 +142,7 @@ describe('enpointParsers', () => {
     it('returns up if the live_lookups check is successful', () => {
       const data = {
         default: { success: true },
-        okapi: { success: true },
+        live_lookups: { success: true },
       };
 
       return expect(

--- a/src/utils/endpointParsers.js
+++ b/src/utils/endpointParsers.js
@@ -25,7 +25,7 @@ export function processGenericOkComputer(response) {
 export function processLiveAvailability(response) {
   return response.json().then((data) => {
     if (typeof data.default === 'undefined') return 'outage';
-    return data.okapi.success ? 'up' : 'outage';
+    return data.live_lookups.success ? 'up' : 'outage';
   }).catch(() => 'outage');
 }
 export function processCitationService(response) {


### PR DESCRIPTION
This reverts commit 22263b389d26bf0fe9240e7599c954397b8b22f2.

Closes #389

Will un-draft once https://github.com/sul-dlss/SearchWorks/pull/3459 is deployed to prod